### PR TITLE
Linked axis lims

### DIFF
--- a/PanGUI/main.py
+++ b/PanGUI/main.py
@@ -70,6 +70,13 @@ class Main(QMainWindow, Ui_MainWindow):
                 sharey = None
             ax = fig1.add_subplot(rows, cols, i+1, sharex=sharex,
                                   sharey=sharey)
+
+            # explicitly update the x- and y-axis limits
+            if sharex is not None:
+                ax.set_xlim(sharex.get_xlim())
+            if sharey is not None:
+                ax.set_ylim(sharex.get_ylim())
+
             nn, newIdx = plotobj.plot(self.index, getNumEvents=True)
             self.numEvents = min(self.numEvents, nn)
             plotobj.plot(self.index, ax=ax, **self.plotopts[i])

--- a/PanGUI/test.py
+++ b/PanGUI/test.py
@@ -92,8 +92,8 @@ def test_same_obj():
 
 def test(linkaxes=True):
     data1 = np.random.random((10, 1000))
-    data2 = np.random.random((10, 1000))
-    data3 = np.random.random((10, 1000))
+    data2 = np.random.random((10, 2000))
+    data3 = np.random.random((10, 3000))
     pp1 = PlotObject(data1, normpath=False)
     pp1.dirs = ["session01/array01/channel001/cell01"]
     pp2 = PlotObject(data2, normpath=False)
@@ -105,7 +105,7 @@ def test(linkaxes=True):
     _pp1.dirs = ["session01/array01/channel001/cell01"]
     pp1.append(_pp1)
 
-    _pp2 = PlotObject(data1, normpath=False)
+    _pp2 = PlotObject(data2, normpath=False)
     _pp2.dirs = ["session01/array01/channel001/cell02"]
     pp2.append(_pp2)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(name="PanGUI",
-      version="0.9.0",
+      version="0.9.1",
       description="Utility to pan through plots",
       url="https://github.com/grero/PanGUI.git",
       author="Roger Herikstad",


### PR DESCRIPTION
This fixes an issue where setting sharex/sharey apparently did not affect the initial limits. Now they are set explicitly based on the axis object for which the current axis shares either the x- or the y-axis.