### PR TITLE
Prevent TypeError from unknown kwarg

### DIFF
--- a/PanGUI/main.py
+++ b/PanGUI/main.py
@@ -170,7 +170,7 @@ class Main(QMainWindow, Ui_MainWindow):
                 self.create_menu(v, subMenu, qpath)
             elif isinstance(v, DPT.objects.ExclusiveOptions):
                 subMenu = menu.addMenu(k)
-                ag = QtWidgets.QActionGroup(self, exclusive=True)
+                ag = QtWidgets.QActionGroup(self, exclusionPolicy=1)
                 for (ii, oo) in enumerate(v.options):
                     action = ag.addAction(QtWidgets.QAction(oo, self, checkable=True))
                     if cpath != "":


### PR DESCRIPTION
Minor change to the kwarg for menu creation as specified in PyQT docs to prevent unknown kwarg errors.
https://doc.qt.io/qt-5/qactiongroup.html#exclusionPolicy-prop
https://doc.qt.io/qt-5/qactiongroup.html#ExclusionPolicy-enum